### PR TITLE
refactor: reduce the installation size

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "tsbw": "tsc -b -v -w"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
     "commander": "^12.0.0",
     "execa": "^8.0.1",
-    "fs-extra": "^11.2.0"
+    "fs-extra": "^11.2.0",
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/package.json
+++ b/package.json
@@ -48,13 +48,11 @@
   "dependencies": {
     "commander": "^12.0.0",
     "execa": "^8.0.1",
-    "fs-extra": "^11.2.0",
     "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@jest/types": "^29.6.3",
-    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.11.17",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  chalk:
-    specifier: ^5.3.0
-    version: 5.3.0
   commander:
     specifier: ^12.0.0
     version: 12.0.0
@@ -17,6 +14,9 @@ dependencies:
   fs-extra:
     specifier: ^11.2.0
     version: 11.2.0
+  picocolors:
+    specifier: ^1.0.0
+    version: 1.0.0
 
 devDependencies:
   '@jest/globals':
@@ -1623,11 +1623,6 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: true
-
-  /chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -3665,7 +3660,6 @@ packages:
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-    dev: true
 
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   execa:
     specifier: ^8.0.1
     version: 8.0.1
-  fs-extra:
-    specifier: ^11.2.0
-    version: 11.2.0
   picocolors:
     specifier: ^1.0.0
     version: 1.0.0
@@ -25,9 +22,6 @@ devDependencies:
   '@jest/types':
     specifier: ^29.6.3
     version: 29.6.3
-  '@types/fs-extra':
-    specifier: ^11.0.4
-    version: 11.0.4
   '@types/node':
     specifier: ^20.11.17
     version: 20.11.17
@@ -1056,13 +1050,6 @@ packages:
       '@babel/types': 7.23.9
     dev: true
 
-  /@types/fs-extra@11.0.4:
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 20.11.17
-    dev: true
-
   /@types/graceful-fs@4.1.9:
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
     dependencies:
@@ -1087,12 +1074,6 @@ packages:
 
   /@types/json-schema@7.0.15:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
-    dev: true
-
-  /@types/jsonfile@6.1.4:
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
-    dependencies:
-      '@types/node': 20.11.17
     dev: true
 
   /@types/node@20.11.17:
@@ -2308,15 +2289,6 @@ packages:
       map-cache: 0.2.2
     dev: true
 
-  /fs-extra@11.2.0:
-    resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
-    engines: {node: '>=14.14'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-    dev: false
-
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
     dev: true
@@ -2421,6 +2393,7 @@ packages:
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+    dev: true
 
   /graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
@@ -3250,14 +3223,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
     dev: true
-
-  /jsonfile@6.1.0:
-    resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-    dev: false
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4214,11 +4179,6 @@ packages:
       is-extendable: 0.1.1
       set-value: 2.0.1
     dev: true
-
-  /universalify@2.0.1:
-    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
-    engines: {node: '>= 10.0.0'}
-    dev: false
 
   /unset-value@1.0.0:
     resolution: {integrity: sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==}

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,5 @@
 import { Console, ConsoleConstructorOptions } from "node:console";
-import { default as chalk } from "chalk";
+import { bold, bgWhite, gray, bgCyan, bgYellow, bgRed, bgBlue, underline } from "picocolors";
 
 class Logger extends Console {
   constructor(
@@ -11,23 +11,23 @@ class Logger extends Console {
     super(consoleOptions);
   }
   debug(...args: any[]) {
-    super.debug(chalk.bgWhite.bold("DEBUG"), ...args);
+    super.debug(bgWhite(bold("DEBUG")), ...args);
   }
   log(...args: any[]) {
-    super.log(chalk.gray.bold("LOG  "), ...args);
+    super.log(gray(bold("LOG  ")), ...args);
   }
   info(...args: any[]) {
-    super.info(chalk.bgCyan.bold("INFO "), ...args);
+    super.info(bgCyan(bold("INFO ")), ...args);
   }
   warn(...args: any[]) {
-    super.warn(chalk.bgYellow.bold("WARN "), ...args);
+    super.warn(bgYellow(bold("WARN ")), ...args);
   }
   error(...args: any[]) {
-    super.error(chalk.bgRed.bold("ERROR"), ...args);
+    super.error(bgRed(bold("ERROR")), ...args);
   }
   group(...args: any[]): void {
     super.log();
-    super.group(chalk.bgBlue.bold.underline(...args));
+    super.group(args.map(arg => bgBlue(bold(underline(arg)))));
   }
   t = super.trace;
   d = super.debug;

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,14 +1,7 @@
 import { Console, ConsoleConstructorOptions } from "node:console";
-import { default as pc } from "picocolors";
-
-const bgWhite = pc.bgWhite;
-const gray = pc.gray;
-const bgCyan = pc.bgCyan;
-const bgYellow = pc.bgYellow;
-const bgRed = pc.bgRed;
-const bgBlue = pc.bgBlue;
-const bold = pc.bold;
-const underline = pc.underline;
+import { default as picocolors } from "picocolors";
+const { bold, bgWhite, gray, bgCyan, bgYellow, bgRed, bgBlue, underline } =
+  picocolors;
 
 class Logger extends Console {
   constructor(

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,14 @@
 import { Console, ConsoleConstructorOptions } from "node:console";
-import { bold, bgWhite, gray, bgCyan, bgYellow, bgRed, bgBlue, underline } from "picocolors";
+import { default as pc } from "picocolors";
+
+const bgWhite = pc.bgWhite;
+const gray = pc.gray;
+const bgCyan = pc.bgCyan;
+const bgYellow = pc.bgYellow;
+const bgRed = pc.bgRed;
+const bgBlue = pc.bgBlue;
+const bold = pc.bold;
+const underline = pc.underline;
 
 class Logger extends Console {
   constructor(
@@ -27,7 +36,7 @@ class Logger extends Console {
   }
   group(...args: any[]): void {
     super.log();
-    super.group(args.map(arg => bgBlue(bold(underline(arg)))));
+    super.group(...args.map((arg) => bgBlue(bold(underline(arg)))));
   }
   t = super.trace;
   d = super.debug;

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ const main = async () => {
       })
       .catch((err) => {
         logger.error("Copy failed: ", err);
+        process.exit(1);
       })
       .finally(() => {
         logger.groupEnd();

--- a/src/main.ts
+++ b/src/main.ts
@@ -193,26 +193,28 @@ const checkPackageManager = (): Promise<PM> => {
 };
 
 const installPackage = (pm: string) => {
-  const cp = execa(pm, ["install"], { cwd: initOptions.blogPath });
-  cp.stdout?.setEncoding("utf8");
-  cp.stdout?.on("data", (data) => {
+  const child = execa(pm, ["install"], {
+    cwd: initOptions.blogPath,
+  });
+  child.stdout?.setEncoding("utf8");
+  child.stdout?.on("data", (data) => {
     logger.log(pm, data);
   });
-  cp.stderr?.setEncoding("utf8");
-  cp.stderr?.on("data", function (data) {
+  child.stderr?.setEncoding("utf8");
+  child.stderr?.on("data", function (data) {
     logger.warn(pm, data);
   });
-  cp.on("error", (err) => {
+  child.on("error", (err) => {
     logger.error("Install error: ", err);
   });
-  cp.on("close", (code) => {
+  child.on("close", (code) => {
     if (code !== 0) {
       logger.error("Install error: ", code);
     } else {
       logger.info("Install package finshed");
     }
   });
-  return cp;
+  return child;
 };
 
 const post = () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,7 +256,7 @@ const post = () => {
   return Promise.all(ls);
 };
 const end = async () => {
-  logger.group("Finshed!", "\n");
+  logger.group("Finshed!");
   logger.info("Enjoy yourself!", "\n");
   logger.groupEnd();
   logger.timeEnd("create-hexo");

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,7 +220,10 @@ const post = () => {
 
   RM_FILES.forEach((item) => {
     ls.push(
-      rm(pathResolve(initOptions.blogPath, item), { force: true, recursive: true })
+      rm(pathResolve(initOptions.blogPath, item), {
+        force: true,
+        recursive: true,
+      })
         .then(() => {
           logger.log(`remove "${item}" success!`);
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,10 @@ const main = async () => {
 
   logger.group(`Copying \`${STARTER}\``);
   const [voidd, pm] = await Promise.all([
-    cp(STARTER_DIR, initOptions.blogPath)
+    cp(STARTER_DIR, initOptions.blogPath, {
+      force: initOptions.force,
+      recursive: true,
+    })
       .then(() => {
         logger.log(`Copied \`${STARTER}\` to "${initOptions.blogPath}"`);
       })


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Passed the CI test.

## Description

- Replace `chalk` with `picocolors`.
- Replace `fs-extra` with Node.js built-in `fs` method.
  - Rename childProcess to avoid confusion

## Additional information

- exit if failed on copying files.
- improve log output of Finished

